### PR TITLE
Add k nearest neighbors and cross validation bandwidth methods

### DIFF
--- a/KDEpy/BaseKDE.py
+++ b/KDEpy/BaseKDE.py
@@ -8,7 +8,7 @@ import numpy as np
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from KDEpy.kernel_funcs import _kernel_functions
-from KDEpy.bw_selection import _bw_methods
+from KDEpy.bw_selection import _bw_methods, cross_val
 from KDEpy.utils import autogrid
 
 
@@ -31,7 +31,7 @@ class BaseKDE(ABC):
     _bw_methods = _bw_methods
 
     @abstractmethod
-    def __init__(self, kernel: str, bw: float):
+    def __init__(self, kernel: str, bw: float, norm: float):
         """Initialize the kernel density estimator.
 
         The return type must be duplicated in the docstring to comply
@@ -59,6 +59,9 @@ class BaseKDE(ABC):
         else:
             raise ValueError(msg)
 
+        # CV method must be added here since it depends on self
+        _bw_methods["CV"] = self.cross_val
+
         # The `bw` paramter may either be a positive number, a string, or
         # array-like such that each point in the data has a uniue bw
         if isinstance(bw, numbers.Number) and bw > 0:
@@ -74,12 +77,15 @@ class BaseKDE(ABC):
         else:
             raise ValueError("Bandwidth must be > 0, array-like or a string.")
 
+        self.norm = norm
+
         # Test quickly that the method has done what is was supposed to do
         assert callable(self.kernel)
         assert isinstance(self.bw_method, (np.ndarray, Sequence, numbers.Number)) or callable(self.bw_method)
+        assert isinstance(self.norm, numbers.Number) and self.norm > 0
 
     @abstractmethod
-    def fit(self, data, weights=None):
+    def fit(self, data, weights=None, **kwargs):
         """
         Fit the kernel density estimator to the data.
         This method converts the data to shape (obs, dims) and the weights
@@ -93,6 +99,8 @@ class BaseKDE(ABC):
         weights : array-like, Sequence or None
             May be array-like of shape (obs,), shape (obs, dims), a
             Python Sequence, e.g. a list or tuple, or None.
+        **kwargs:
+            List of arguments to be passed to bandwidth optimization method.
         """
 
         # -------------- Set up the data depending on input -------------------
@@ -126,7 +134,7 @@ class BaseKDE(ABC):
         if isinstance(self.bw_method, (np.ndarray, Sequence)):
             self.bw = self.bw_method
         elif callable(self.bw_method):
-            self.bw = self.bw_method(self.data, self.weights)
+            self.bw = self.bw_method(self.data, self.weights, **kwargs)
         else:
             self.bw = self.bw_method
 
@@ -174,6 +182,75 @@ class BaseKDE(ABC):
             assert isinstance(bw, numbers.Number)
             assert bw > 0
         assert len(self.grid_points.shape) == 2
+
+    def score(self, test_data, test_weights=None):
+        """
+        Computes the score of test data on the KDE model. The score is
+        calculated as the total log-probability of the test samples
+        on the model. The method takes into account test weights, and
+        works with variable bandwidths.
+
+        Parameters
+        ----------
+        test_data : array-like or Sequence
+            May be array-like of shape (obs,), shape (obs, dims) or a
+            Python Sequence, e.g. a list or tuple.
+        test_weights : array-like, Sequence or None
+            May be array-like of shape (obs,), shape (obs, dims), a
+            Python Sequence, e.g. a list or tuple, or None.
+        """
+
+        # -------------- Set up the data depending on input -------------------
+        # In the end, the data should be an ndarray of shape (obs, dims)
+        test_data = self._process_sequence(test_data)
+
+        obs, dims = test_data.shape
+
+        if not obs > 0:
+            raise ValueError("Test data must contain at least one data point.")
+        assert dims > 0
+
+        # -------------- Set up the weights depending on input ----------------
+        if test_weights is not None:
+            test_weights = _process_sequence(test_weights).ravel()
+            if not obs == len(test_weights):
+                raise ValueError("Number of test data obs must match test weights")
+
+            return np.sum(test_weights * np.log(self.evaluate(test_data)))
+        
+        return np.sum(np.log(self.evaluate(test_data)))
+
+    def cross_val(data, weights=None, cv=10, seed=None, grid=None):
+        """
+        Computes the cross validated score over a grid of bandwidths, and returns
+        the one that maximizes it. It is a robust method against multimodal
+        distributions, and can be performed on variable bandwidths (e.g.: by
+        setting "seed" parameter as the output of k nearest neighbors algorithm).
+    
+        Habbema, J. D. F., Hermans, J., and Van den Broek, K. (1974) A stepwise
+        discrimination analysis program using density estimation.
+    
+        Leave-one-out MLCV method in R: https://rdrr.io/cran/kedd/man/h.mlcv.html
+    
+        Parameters
+        ----------
+        data: array-like
+            The data points. Data must have shape (obs, dims).
+        weights: array-like, 
+            One weight per data point. Numbers of observations must match
+            the data points.
+        cv: int
+            The number of cross validation folds. If cv equals obs, it is the
+            leave-one-out cross validation.
+        seed : float or array-like
+            The seed bandwidth. By default is a simplified version of the silverman
+            rule.
+        grid : array-like
+            The grid of factors. The bandwidth grid is constructed as:
+            bw_grid[i] = bw * grid[i]
+            By default is np.logspace(-1,1,20)
+        """
+        return cross_val(self, data, weights=weights, cv=cv, seed=seed, grid=grid)
 
     @staticmethod
     def _process_sequence(sequence_array_like):

--- a/KDEpy/FFTKDE.py
+++ b/KDEpy/FFTKDE.py
@@ -68,11 +68,9 @@ class FFTKDE(BaseKDE):
     """
 
     def __init__(self, kernel="gaussian", bw=1, norm=2):
-        self.norm = norm
-        super().__init__(kernel, bw)
-        assert isinstance(self.norm, numbers.Number) and self.norm > 0
+        super().__init__(kernel, bw, norm)
 
-    def fit(self, data, weights=None):
+    def fit(self, data, weights=None, **kwargs):
         """
         Fit the KDE to the data. This validates the data and stores it.
         Computations are performed upon evaluation on a specific grid.
@@ -83,6 +81,8 @@ class FFTKDE(BaseKDE):
             The data points.
         weights: array-like
             One weight per data point. Must have same shape as the data.
+        **kwargs:
+            List of arguments to be passed to bandwidth optimization method.
 
         Returns
         -------
@@ -99,7 +99,7 @@ class FFTKDE(BaseKDE):
         """
 
         # Sets self.data
-        super().fit(data, weights)
+        super().fit(data, weights, **kwargs)
         return self
 
     def evaluate(self, grid_points=None):

--- a/KDEpy/NaiveKDE.py
+++ b/KDEpy/NaiveKDE.py
@@ -50,10 +50,9 @@ class NaiveKDE(BaseKDE):
     """
 
     def __init__(self, kernel="gaussian", bw=1, norm=2):
-        super().__init__(kernel, bw)
-        self.norm = norm
+        super().__init__(kernel, bw, norm)
 
-    def fit(self, data, weights=None):
+    def fit(self, data, weights=None, **kwargs):
         """
         Fit the KDE to the data. This validates the data and stores it.
         Computations are performed when the KDE is evaluated on a grid.
@@ -65,6 +64,8 @@ class NaiveKDE(BaseKDE):
         weights: array-like
             One weight per data point. Must have shape (obs,). If None is
             passed, uniform weights are used.
+        **kwargs:
+            List of arguments to be passed to bandwidth optimization method.
 
         Returns
         -------
@@ -80,7 +81,7 @@ class NaiveKDE(BaseKDE):
         >>> x, y = kde()
         """
         # Sets self.data
-        super().fit(data, weights)
+        super().fit(data, weights, **kwargs)
         return self
 
     def evaluate(self, grid_points=None):

--- a/KDEpy/TreeKDE.py
+++ b/KDEpy/TreeKDE.py
@@ -60,10 +60,9 @@ class TreeKDE(BaseKDE):
     """
 
     def __init__(self, kernel="gaussian", bw=1, norm=2.0):
-        super().__init__(kernel, bw)
-        self.norm = norm
+        super().__init__(kernel, bw, norm)
 
-    def fit(self, data, weights=None):
+    def fit(self, data, weights=None, **kwargs):
         """
         Fit the KDE to the data. This validates the data and stores it.
         Computations are performed upon evaluation on a grid.
@@ -75,6 +74,8 @@ class TreeKDE(BaseKDE):
         weights: array-like
             One weight per data point. Numbers of observations must match
             the data points.
+        **kwargs:
+            List of arguments to be passed to bandwidth optimization method.
 
         Returns
         -------
@@ -90,7 +91,7 @@ class TreeKDE(BaseKDE):
         >>> x, y = kde()
         """
         # Sets self.data
-        super().fit(data, weights)
+        super().fit(data, weights, **kwargs)
         return self
 
     def evaluate(self, grid_points=None, eps=10e-4):

--- a/KDEpy/bw_selection.py
+++ b/KDEpy/bw_selection.py
@@ -3,13 +3,16 @@
 """
 Functions for bandwidth selection.
 """
+import numbers
 import numpy as np
 import scipy
 import warnings
+from collections.abc import Sequence
 from KDEpy.binning import linear_binning
 from KDEpy.utils import autogrid
 from scipy import fftpack
 from scipy.optimize import brentq
+from scipy.spatial import KDTree
 
 # Choose the largest available float on the system
 try:
@@ -292,8 +295,253 @@ Setting bw = {}".format(
         return 1.0
 
 
+def k_nearest_neighbors(data, weights=None, k=10, batch_size=10000):
+    """
+    Computes variable bandwidth based on k nearest neighbors algorithm on data.
+    For each data point, sets its bandwidth as the euclidean distance to the
+    kth nearest neighbor within its batch. The computation is performed on
+    batches to allow scalability to large datasets. The scipy KDTree class is
+    used for the nearest neighbors queries.
+
+    https://en.wikipedia.org/wiki/Variable_kernel_density_estimation
+    https://en.wikipedia.org/wiki/K-nearest_neighbour_algorithm
+    https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.KDTree.html
+
+    Parameters
+    ----------
+    data: array-like
+        The data points. Data must have shape (obs, dims).
+    weights: array-like, 
+        Ignored, only for compatibility
+    k: int
+        Number of neighbors per batch (without counting self)
+    batch_size: int
+        Aproximate size of each batch. Will be slightly modified to cover
+        dataset as uniformly as possible.
+    """
+    if not len(data.shape) == 2:
+        raise ValueError("Data must be of shape (obs, dims).")
+    obs, dims = data.shape
+
+    if weights is not None:
+        warnings.warn("K nearest neighbors ignores all weights")
+
+    if obs < 2:
+        raise ValueError("Data must be of length >= 2.")
+
+    if k < 1 or k >= batch_size:
+        raise ValueError("k must be between 1 and batch_size-1.")
+    k = int(k)
+
+    if batch_size < 2:
+        raise ValueError("Batch size must be >= 2.")
+
+    batches = int(max(1, np.round(obs / batch_size)))
+    batch_size = int(obs / batches)
+    print("Using k = {} neighbors per batch (batch size = {})".format(k, batch_size))
+    print("Equivalent to aprox. {} total neighbors".format(k*batches))
+
+    # This could be easily run in parallel, improving performance, but it would
+    # require depending on an external library (e.g.: joblib)
+    bw_knn = np.array([])
+    for batch,batch_data in enumerate(np.array_split(data, batches)):
+        print("K Nearest Neighbors: batch = {} of {}".format(batch+1, batches))
+        kdtree = KDTree(batch_data)
+        # Use k+1 to take into account dist=0 between each point and self
+        dists,idxs = kdtree.query(batch_data, k=k+1)
+        bw_knn = np.concatenate((bw_knn, dists[:,-1]))
+    return bw_knn
+
+
+def _cv_score(model, bw, data, weights=None, cv=10):
+    """
+    Computes cross validated score of KDE model, which gives an indicator of
+    the quality of the estimation. Test and train data are taken following a
+    K-folds cross validation scheme.
+
+    Parameters
+    ----------
+    model: NaiveKDE() or TreeKDE()
+        The model to be used to evaluate scores. Technically it could be any
+        object that implements methods __init__, fit and evaluate (on arbitrary
+        grid) with the same syntax than KDEpy.
+    bw : float or array-like
+        Bandwidth. If a float is passed, it is the standard deviation of the
+        kernel. If an array-like it passed, it is the bandwidth of each point.
+    data: array-like
+        The data points. Data must have shape (obs, dims).
+    weights: array-like, 
+        One weight per data point. Numbers of observations must match
+        the data points.
+    cv: int
+        The number of cross validation folds. If cv equals obs, it is the
+        leave-one-out cross validation.
+    """
+    if not len(data.shape) == 2:
+        raise ValueError("Data must be of shape (obs, dims).")
+    obs, dims = data.shape
+
+    if obs < 2:
+        raise ValueError("Data must be of length >= 2.")
+
+    if weights is not None:
+        if not weights.shape == (obs,):
+            raise ValueError("Number of weights must match data points")
+
+    if cv > len(data):
+        cv = len(data)
+    if cv < 2:
+        raise ValueError("Number of folds must be >= 2.")
+
+    if isinstance(bw, numbers.Number) and bw > 0:
+        variable_bw = False
+    elif isinstance(bw, (np.ndarray, Sequence)):
+        if not bw.shape == (obs,):
+            raise ValueError("If bandwidth is variable, it must match data points")
+        folds_bw = np.array_split(bw, cv)
+        variable_bw = True
+    else:
+        raise ValueError("Bandwidth must be > 0, or array-like.")
+
+    # Folds for cross validation
+    folds_data = np.array_split(data, cv)
+    if weights is not None:
+        folds_weights = np.array_split(weights, cv)
+    else:
+        folds_weights = cv * [None]
+    folds_score = []
+
+    # Compute cross validation for each fold
+    for fold,[test_data,test_weights] in enumerate(zip(folds_data,folds_weights)):
+        if variable_bw:
+            train_bw = np.concatenate(folds_bw[:fold]+folds_bw[fold+1:], axis=0)
+        else:
+            train_bw = bw
+        kde = model.__class__(kernel=model.kernel, bw=train_bw, norm=model.norm)
+        train_data = np.concatenate(folds_data[:fold]+folds_data[fold+1:], axis=0)
+        if weights is not None:
+            train_weights = np.concatenate(folds_weights[:fold]+folds_weights[fold+1:], axis=0)
+        else:
+            train_weights = None
+        kde.fit(train_data, weights=train_weights)
+        folds_score.append(kde.score(test_data,test_weights))
+
+    return np.mean(folds_score)
+
+
+def grid_search_cv(model, bw_grid, data, weights=None, cv=10):
+    """
+    Computes the cross validated score over a grid of bandwidths, and returns
+    the list of cv scores.
+
+    Parameters
+    ----------
+    model: NaiveKDE() or TreeKDE()
+        The model to be used to evaluate scores. Technically it could be any
+        object that implements methods __init__, fit and evaluate (on arbitrary
+        grid) with the same syntax than KDEpy.
+    bw_grid : array-like
+        The grid of bandwidths. Each element can be a float or an array of
+        shape (obs,).
+    data: array-like
+        The data points. Data must have shape (obs, dims).
+    weights: array-like, 
+        One weight per data point. Numbers of observations must match
+        the data points.
+    cv: int
+        The number of cross validation folds. If cv equals obs, it is the
+        leave-one-out cross validation.
+    """
+    if not len(data.shape) == 2:
+        raise ValueError("Data must be of shape (obs, dims).")
+    obs, dims = data.shape
+
+    if obs < 2:
+        raise ValueError("Data must be of length >= 2.")
+
+    assert isinstance(bw_grid, (Sequence, np.ndarray))
+
+    # This could be easily run in parallel, improving performance, but it would
+    # require depending on an external library (e.g.: joblib)
+    cv_scores = []
+    for idx,bw in enumerate(bw_grid):
+        print("Cross Validation: evaluating bandwidth {} of {}".format(idx+1, len(bw_grid)))
+        cv_scores.append(_cv_score(model, bw, data, weights=weights, cv=cv))
+    
+    return cv_scores
+
+
+def cross_val(model, data, weights=None, cv=10, seed=None, grid=None):
+    """
+    Computes the cross validated score over a grid of bandwidths, and returns
+    the one that maximizes it. It is a robust method against multimodal
+    distributions, and can be performed on variable bandwidths (e.g.: by
+    setting "seed" parameter as the output of k nearest neighbors algorithm).
+
+    Habbema, J. D. F., Hermans, J., and Van den Broek, K. (1974) A stepwise
+    discrimination analysis program using density estimation.
+
+    Leave-one-out MLCV method in R: https://rdrr.io/cran/kedd/man/h.mlcv.html
+
+    Parameters
+    ----------
+    model: NaiveKDE() or TreeKDE()
+        The model to be used to evaluate scores. Technically it could be any
+        object that implements methods __init__, fit and evaluate (on arbitrary
+        grid) with the same syntax than KDEpy.
+    bw : float or array-like
+    data: array-like
+        The data points. Data must have shape (obs, dims).
+    weights: array-like, 
+        One weight per data point. Numbers of observations must match
+        the data points.
+    cv: int
+        The number of cross validation folds. If cv equals obs, it is the
+        leave-one-out cross validation.
+    seed : float or array-like
+        The seed bandwidth. By default is a simplified version of the silverman
+        rule.
+    grid : array-like
+        The grid of factors. The bandwidth grid is constructed as:
+        bw_grid[i] = bw * grid[i]
+        By default is np.logspace(-1,1,20)
+    """
+    if not len(data.shape) == 2:
+        raise ValueError("Data must be of shape (obs, dims).")
+    obs, dims = data.shape
+
+    if obs < 2:
+        raise ValueError("Data must be of length >= 2.")
+
+    if seed is None:
+        # This should be replaced by a call to silverman_rule when it is
+        # implemented for multidimensional data
+        sigma = np.std(data, axis=0).mean()
+        seed = sigma * (obs * (2.0+dims/4)) ** (-1/(4+dims))
+
+    if grid is None:
+        grid = np.logspace(-1, 1, 20)
+
+    bw_grid = np.reshape(grid, (-1,*np.ones(np.ndim(seed),dtype=int))) * seed
+
+    cv_scores = grid_search_cv(model, bw_grid, data, weights=weights, cv=cv)
+    idx_best = np.argmax(cv_scores)
+
+    # Warn if maximum was in beginning or end of grid
+    if idx_best in (0, len(bw_grid)-1):
+        # Could calculate new grid automatically and call recursively
+        msg = "Could not find maximum in the selected range of bandwidths.\n"
+        msg += "Move grid and try again."
+        warnings.warn(msg)
+
+    bw_cv = bw_grid[idx_best]
+    return bw_cv
+
+
 _bw_methods = {
     "silverman": silvermans_rule,
     "scott": scotts_rule,
     "ISJ": improved_sheather_jones,
+    "knn": k_nearest_neighbors,
+    # CV can not be added here since it requires a model
 }

--- a/KDEpy/tests/test_bw_selection.py
+++ b/KDEpy/tests/test_bw_selection.py
@@ -7,7 +7,9 @@ Tests for the bandwidth selection.
 import pytest
 import numpy as np
 
-from KDEpy.bw_selection import _bw_methods, improved_sheather_jones
+from KDEpy.bw_selection import (_bw_methods, improved_sheather_jones,
+    k_nearest_neighbors, cross_val)
+from KDEpy.TreeKDE import TreeKDE
 
 
 @pytest.fixture(scope="module")
@@ -42,6 +44,34 @@ def test_isj_bw_weights_same_as_resampling(data, execution_number):
     np.testing.assert_array_almost_equal(
         improved_sheather_jones(data_resampled),
         improved_sheather_jones(data, sample_weights),
+    )
+
+
+@pytest.mark.parametrize("dims", [1,2,3])
+def test_knn_with_2_points(dims):
+    data = np.zeros((2,dims))
+    data[0,0] = 0
+    data[1,0] = 1
+    # Distances must be [1,1]
+    np.testing.assert_array_almost_equal(
+        k_nearest_neighbors(data, k=1),
+        np.array([1, 1])
+    )
+
+
+@pytest.mark.parametrize("dims", [1,2,3])
+def test_cv_with_2_points(dims):
+    data = np.zeros((2,dims))
+    data[0,0] = 0
+    data[1,0] = 1
+    # The optimal bw can be found analytically by solving:
+    # d log(kernel(1,bw)) / d bw = 0
+    # For kernel="gaussian" and norm=2.0 it gives:
+    bw_optimal = 1 / np.sqrt(dims)
+    grid = np.logspace(-0.01, 0.01, 5) # Make grid of factors around 1
+    np.allclose(
+        cross_val(TreeKDE(), data, seed=bw_optimal, grid=grid),
+        bw_optimal
     )
 
 


### PR DESCRIPTION
Two automatic bandwidth selection methods were added:
- k nearest neighbors: Calculates the bw for each data point as the distance to the kth neighbor
- cross validated bandwidth: based on a (new) `grid_search_cv` function, wich computes the score over a grid of bandwidths. A score method was added to BaseKDE for that purpose. Since `grid_search_cv` requires a model, the cv bw method could not be implemented as an independent function. Instead it is a method of `BaseKDE` that calls `grid_search_cv` with `model=self` (thru and intermediate function `cross_val`, which chooses the best bw according to the grid search).

Since both method require parameters other than `data` and `weights`, a slight change was introduced to the API:
`fit` method now have the signature `fit(self, data, weights=None, **kwargs)`, where `**kwargs` are the keyword arguments to be passed to the bw selection method. If no `**kwargs` is passed, the default parameters will be used, so the change is backwards compatible.

There is an issue in which I'd like to know your opinion. Both methods are quite computationally expensive (for large datasets), so they could benefit from CPU parallelization, which is quite easy to add with `joblib` library. On the other hand, this would go against the guideline "Import as few external dependencies as possible". Let me know which option you'd prefer.