### PR TITLE
Add pyproject.toml: PEP 517, 518, 631

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "KDEpy"
+version = "1.1.1"
+dependencies = [
+    "numpy>=1.14.2",
+    "numpydoc>=0.7.0",
+    "scipy>=1.0.1",
+    "nbsphinx>=0.3.2",
+    "pytest>=3.6.2",
+    "matplotlib>=2.2.2",
+    "ipython>=6.4.0",
+    "cython>=0.29",
+    "setuptools>=39.2.0",
+]
+
+[build-system]
+requires = ["setuptools>=45", "wheel", "Cython", "numpy>=1.14.2"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Add a `pyproject.toml` file, compliant with the following PEPs:

**PEP 517:** Specify the build backend (setuptools).

**PEP 518:** Specify the build-time dependencies (Cython, and Numpy).

**PEP 631:** Specify the run-time dependencies.

---

**Background:**

There was no pre-built wheel available for my machine, so I was attempting to add the repo as a dependency to be built locally.

PEP 517 and 518 compliance lets KDEpy be automatically and correctly built locally by common Python dependency managers and build systems.

Without the `[build-system]` section in pyproject.toml, the build-time dependencies would not be added to PATH during the build, which would cause it to fail.

PEP 631 makes sure common Python dependency managers install the right packages for when the built package is used.

KDEpy can now be built with `pip3 install .`, and pip will automatically install all the dependencies and compile KDEpy in one go. The same is true when KDEpy is added as a dependency to another project's `pyproject.toml` file. A PEP 517, 518, and 631 dependency manager and build system will be able to automatically build and install everything.

This may or may not sidestep the kinds of issues being reported in #114.