### PR TITLE
Disallow breaking version of Cython (3.0.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 name = "KDEpy"
 version = "1.1.4"
 dependencies = [
-    "numpy>=1.14.2",
-    "scipy>=1.0.1",
+    "numpy>=1.14.2,<2.0",
+    "scipy>=1.0.1,<2.0",
     "matplotlib>=2.2.2",
 ]
 description = "Kernel Density Estimation in Python."
@@ -40,5 +40,5 @@ lint = [
 ]
 
 [build-system]
-requires = ["setuptools>=45", "wheel", "cython>=0.29", "numpy>=1.14.2"]
+requires = ["setuptools>=45", "wheel", "cython>=0.29,<1.0.0", "numpy>=1.14.2,<2.0"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Cython 3.0.0 was recently released, which contains a breaking change in how numbers are handled.

This broke the build as the `cython>=0.29` requirement would mean that the latest version (3.0.0) would be used.

- Disallow new major versions of Cython.
- While I'm here, disallow new major versions of numpy and scipy, as it's highly likely those would suddenly break the build as well.