### PR TITLE
Release 1.1.5 with fixed cython build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "KDEpy"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
     "numpy>=1.14.2,<2.0",
     "scipy>=1.0.1,<2.0",


### PR DESCRIPTION
Follow-up to #148.

Should have done this in that PR. Sorry.

A release is warranted as 1.1.4 won't build from source right now.