### PR TITLE
Fix Numpy and Scipy deprecation warnings

### DIFF
--- a/KDEpy/bw_selection.py
+++ b/KDEpy/bw_selection.py
@@ -72,7 +72,8 @@ def _fixed_point(t, N, I_sq, a2):
         # but this is faster so and requires an import less
 
         # Step one: estimate t_s from |f^(s+1)|^2
-        odd_numbers_prod = np.product(np.arange(1, 2 * s + 1, 2, dtype=FLOAT))
+        # odd_numbers_prod = np.product(np.arange(1, 2 * s + 1, 2, dtype=FLOAT))
+        odd_numbers_prod = np.prod(np.arange(1, 2 * s + 1, 2, dtype=FLOAT))
         K0 = odd_numbers_prod / np.sqrt(2 * np.pi)
         const = (1 + (1 / 2) ** (s + 1 / 2)) / 3
         time = np.power((2 * const * K0 / (N * f)), (2.0 / (3.0 + 2.0 * s)))

--- a/KDEpy/kernel_funcs.py
+++ b/KDEpy/kernel_funcs.py
@@ -292,7 +292,7 @@ class Kernel(collections.abc.Callable):
         else:
 
             def f(x):
-                return self.evaluate(x, bw=bw) - atol
+                return self.evaluate(x, bw=bw)[0] - atol
 
             try:
                 xtol = 1e-3

--- a/KDEpy/tests/test_kernel_funcs.py
+++ b/KDEpy/tests/test_kernel_funcs.py
@@ -56,8 +56,9 @@ class TestKernelFunctions:
             a, b = -function.support, function.support
         else:
             a, b = -5 * function.var, 5 * function.var
-        ff=lambda x:function(x)[0] # converts array of single float to float for compatibility with numpy >= 1.25
-        integral, abserr = quad(ff, a=a, b=b)
+        def function_float(x):
+            return function(x)[0]
+        integral, _ = quad(function_float, a=a, b=b)
         assert np.isclose(integral, 1)
 
     @pytest.mark.parametrize(
@@ -75,10 +76,10 @@ class TestKernelFunctions:
         a, b = -function.support, function.support
 
         # Perform integration 2D
-        def int2D(x1, x2):
+        def function_float(x1, x2):
             return function([[x1, x2]], norm=p)[0]
-
-        ans, err = scipy.integrate.nquad(int2D, [[a, b], [a, b]], opts={"epsabs": 10e-2, "epsrel": 10e-2})
+        opts = {"epsabs": 10e-2, "epsrel": 10e-2}
+        ans, _ = scipy.integrate.nquad(function_float, [[a, b], [a, b]], opts=opts)
 
         assert np.allclose(ans, 1, rtol=10e-4, atol=10e-4)
 
@@ -94,10 +95,10 @@ class TestKernelFunctions:
         a, b = -function.support, function.support
 
         # Perform integration 2D
-        def int2D(x1, x2, x3):
+        def function_float(x1, x2, x3):
             return function([[x1, x2, x3]], norm=p)[0]
-
-        ans, err = scipy.integrate.nquad(int2D, [[a, b], [a, b], [a, b]], opts={"epsabs": 10e-1, "epsrel": 10e-1})
+        opts = {"epsabs": 10e-1, "epsrel": 10e-1}
+        ans, _ = scipy.integrate.nquad(function_float, [[a, b], [a, b], [a, b]], opts=opts)
 
         assert np.allclose(ans, 1, rtol=10e-2, atol=10e-2)
 
@@ -122,10 +123,10 @@ class TestKernelFunctions:
             a, b = -6, 6
 
         # Perform integration 2D
-        def int2D(x1, x2):
+        def function_float(x1, x2):
             return function([[x1, x2]], norm=p)[0]
-
-        ans, err = scipy.integrate.nquad(int2D, [[a, b], [a, b]], opts={"epsabs": 10e-1, "epsrel": 10e-1})
+        opts = {"epsabs": 10e-1, "epsrel": 10e-1}
+        ans, _ = scipy.integrate.nquad(function_float, [[a, b], [a, b]], opts=opts)
 
         assert np.allclose(ans, 1, rtol=10e-3, atol=10e-3)
 
@@ -151,10 +152,10 @@ class TestKernelFunctions:
             a, b = -4, 4
 
         # Perform integration 2D
-        def int2D(x1, x2, x3):
+        def function_float(x1, x2, x3):
             return function([[x1, x2, x3]], norm=p)[0]
-
-        ans, err = scipy.integrate.nquad(int2D, [[a, b], [a, b], [a, b]], opts={"epsabs": 10e-1, "epsrel": 10e-1})
+        opts = {"epsabs": 10e-1, "epsrel": 10e-1}
+        ans, _ = scipy.integrate.nquad(function_float, [[a, b], [a, b], [a, b]], opts=opts)
 
         assert np.allclose(ans, 1, rtol=10e-2, atol=10e-2)
 

--- a/KDEpy/tests/test_kernel_funcs.py
+++ b/KDEpy/tests/test_kernel_funcs.py
@@ -56,7 +56,8 @@ class TestKernelFunctions:
             a, b = -function.support, function.support
         else:
             a, b = -5 * function.var, 5 * function.var
-        integral, abserr = quad(function, a=a, b=b)
+        ff=lambda x:function(x)[0] # converts array of single float to float for compatibility with numpy >= 1.25
+        integral, abserr = quad(ff, a=a, b=b)
         assert np.isclose(integral, 1)
 
     @pytest.mark.parametrize(
@@ -75,7 +76,7 @@ class TestKernelFunctions:
 
         # Perform integration 2D
         def int2D(x1, x2):
-            return function([[x1, x2]], norm=p)
+            return function([[x1, x2]], norm=p)[0]
 
         ans, err = scipy.integrate.nquad(int2D, [[a, b], [a, b]], opts={"epsabs": 10e-2, "epsrel": 10e-2})
 
@@ -94,7 +95,7 @@ class TestKernelFunctions:
 
         # Perform integration 2D
         def int2D(x1, x2, x3):
-            return function([[x1, x2, x3]], norm=p)
+            return function([[x1, x2, x3]], norm=p)[0]
 
         ans, err = scipy.integrate.nquad(int2D, [[a, b], [a, b], [a, b]], opts={"epsabs": 10e-1, "epsrel": 10e-1})
 
@@ -122,7 +123,7 @@ class TestKernelFunctions:
 
         # Perform integration 2D
         def int2D(x1, x2):
-            return function([[x1, x2]], norm=p)
+            return function([[x1, x2]], norm=p)[0]
 
         ans, err = scipy.integrate.nquad(int2D, [[a, b], [a, b]], opts={"epsabs": 10e-1, "epsrel": 10e-1})
 
@@ -151,7 +152,7 @@ class TestKernelFunctions:
 
         # Perform integration 2D
         def int2D(x1, x2, x3):
-            return function([[x1, x2, x3]], norm=p)
+            return function([[x1, x2, x3]], norm=p)[0]
 
         ans, err = scipy.integrate.nquad(int2D, [[a, b], [a, b], [a, b]], opts={"epsabs": 10e-1, "epsrel": 10e-1})
 

--- a/KDEpy/tests/test_kernel_funcs.py
+++ b/KDEpy/tests/test_kernel_funcs.py
@@ -56,8 +56,10 @@ class TestKernelFunctions:
             a, b = -function.support, function.support
         else:
             a, b = -5 * function.var, 5 * function.var
+
         def function_float(x):
             return function(x)[0]
+
         integral, _ = quad(function_float, a=a, b=b)
         assert np.isclose(integral, 1)
 
@@ -78,6 +80,7 @@ class TestKernelFunctions:
         # Perform integration 2D
         def function_float(x1, x2):
             return function([[x1, x2]], norm=p)[0]
+
         opts = {"epsabs": 10e-2, "epsrel": 10e-2}
         ans, _ = scipy.integrate.nquad(function_float, [[a, b], [a, b]], opts=opts)
 
@@ -97,6 +100,7 @@ class TestKernelFunctions:
         # Perform integration 2D
         def function_float(x1, x2, x3):
             return function([[x1, x2, x3]], norm=p)[0]
+
         opts = {"epsabs": 10e-1, "epsrel": 10e-1}
         ans, _ = scipy.integrate.nquad(function_float, [[a, b], [a, b], [a, b]], opts=opts)
 
@@ -125,6 +129,7 @@ class TestKernelFunctions:
         # Perform integration 2D
         def function_float(x1, x2):
             return function([[x1, x2]], norm=p)[0]
+
         opts = {"epsabs": 10e-1, "epsrel": 10e-1}
         ans, _ = scipy.integrate.nquad(function_float, [[a, b], [a, b]], opts=opts)
 
@@ -154,6 +159,7 @@ class TestKernelFunctions:
         # Perform integration 2D
         def function_float(x1, x2, x3):
             return function([[x1, x2, x3]], norm=p)[0]
+
         opts = {"epsabs": 10e-1, "epsrel": 10e-1}
         ans, _ = scipy.integrate.nquad(function_float, [[a, b], [a, b], [a, b]], opts=opts)
 


### PR DESCRIPTION
Fix Numpy and Scipy deprecation warnings.

Changes:
- numpy.product() -> numpy.prod()
- array to float conversion for functions used by scipy.integrate.quad/quadn and scipy.optimize.brentq

Setup:
- Python 3.12.2
- Numpy 1.26.4
- Scipy 1.12.0

Verification:

 I ran pytest and got 573 passed tests; 0 failues; 43 skipped (also ran these tests; all passed); 94 warnings. The warning are related to: a) Silverman and Scott methods with multiples weights (92 warnings), b) datetime deprecation (does not seem to be related to KDEpy)

Note:
There is another instance of brentq in bw_selection.py that did not emit warnings during testing. Code was left as is, but more testing could eventually reveal additional deprecation warnings. The easy fix would be to wrap the function using a lambda function:
```
ff=lambda x:function(x)[0]
x, res = brentq(ff, 0, tol, args=args, full_output=True, disp=False)
```