### PR TITLE
Python 3.14 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install cibuildwheel
         run: |
           pip install --upgrade pip
-          pip install cibuildwheel==2.21.3
+          pip install cibuildwheel==3.2.1
       
       - name: Set up QEMU
         if: runner.os == 'Linux'
@@ -34,7 +34,7 @@ jobs:
 
       - name: Build wheels
         env:
-          CIBW_BUILD: 'cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*'
+          CIBW_BUILD: 'cp38-* cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*'
           CIBW_ARCHS_LINUX: auto aarch64
           CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_SKIP: pp* *-musllinux_* *-manylinux_i686  # skip PyPy, musllinux, 32-bit Linux

--- a/.github/workflows/test_base.yml
+++ b/.github/workflows/test_base.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false # Allow one of the matrix builds to fail without failing others
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 [project.urls]


### PR DESCRIPTION
`python3.14 setup.py bdist_wheel` runs clean for me on Mac, so there is some chance that unlike https://github.com/tommyod/KDEpy/pull/174 , this will Just Work without code changes.

We do need to update cibuildwheel to a version which supports Python 3.14, which means a major version change there.  The changelog for cibuildwheel 3.0.0 at

 * https://cibuildwheel.pypa.io/en/stable/changelog/#v300

does show some rather large changes such as

> * Invokes "build" rather than "pip wheel" to build wheels by default.
> * Build environments no longer have setuptools and wheel preinstalled.

Worth noting but not addressed here:
 * freethreaded Python 3.14 is stable now
 * Python 3.8 is EOL
 * Python 3.9 will be EOL in a few days

Thanks for this great library!